### PR TITLE
Enable PQ TLS, cleanup code, and fix edge cases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,10 @@
         <artifactId>acmpca</artifactId>
       </dependency>
       <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>aws-crt-client</artifactId>
+      </dependency>
+      <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk18on</artifactId>
         <version>1.81</version>

--- a/pom.xml
+++ b/pom.xml
@@ -95,5 +95,15 @@
         <artifactId>bcpkix-jdk18on</artifactId>
         <version>1.81</version>
       </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>1.7.5</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-log4j12</artifactId>
+        <version>1.7.5</version>
+      </dependency>
     </dependencies>
   </project>

--- a/src/main/java/com/amazonaws/acmpcakms/examples/AsymmetricCMK.java
+++ b/src/main/java/com/amazonaws/acmpcakms/examples/AsymmetricCMK.java
@@ -21,7 +21,8 @@ import org.bouncycastle.pkcs.PKCS10CertificationRequestBuilder;
 import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
 import org.bouncycastle.util.io.pem.PemObjectGenerator;
 import org.bouncycastle.util.io.pem.PemWriter;
-import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.*;
 
@@ -40,7 +41,10 @@ public class AsymmetricCMK {
       throw new IllegalArgumentException("An algorithm family must be specified");
     }
 
-    this.client = KmsClient.builder().region(Region.US_EAST_1).build();
+    // Set up a PQ TLS HTTP client that will be used when connecting to AWS
+    SdkHttpClient awsCrtHttpClient = AwsCrtHttpClient.builder().postQuantumTlsEnabled(true).build();
+
+    this.client = KmsClient.builder().httpClient(awsCrtHttpClient).build();
     this.alias = alias;
     this.algorithmFamily = algorithmFamily;
 

--- a/src/main/java/com/amazonaws/acmpcakms/examples/PrivateCA.java
+++ b/src/main/java/com/amazonaws/acmpcakms/examples/PrivateCA.java
@@ -3,7 +3,8 @@ package com.amazonaws.acmpcakms.examples;
 import com.amazonaws.acmpcakms.examples.algorithms.AlgorithmFamily;
 import java.util.*;
 import software.amazon.awssdk.core.SdkBytes;
-import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
 import software.amazon.awssdk.services.acmpca.AcmPcaClient;
 import software.amazon.awssdk.services.acmpca.model.*;
 import software.amazon.awssdk.services.acmpca.waiters.AcmPcaWaiter;
@@ -42,7 +43,10 @@ public class PrivateCA {
       throw new IllegalArgumentException("A subordinate CA must have an issuer specified");
     }
 
-    this.client = AcmPcaClient.builder().region(Region.US_EAST_1).build();
+    // Set up a PQ TLS HTTP client that will be used when connecting to AWS
+    SdkHttpClient awsCrtHttpClient = AwsCrtHttpClient.builder().postQuantumTlsEnabled(true).build();
+
+    this.client = AcmPcaClient.builder().httpClient(awsCrtHttpClient).build();
     this.commonName = commonName;
     this.type = type;
     this.algorithmFamily = algorithmFamily;
@@ -79,7 +83,13 @@ public class PrivateCA {
 
   private boolean matches(CertificateAuthority ca) {
     return type.equals(ca.type())
-        && commonName.equals(ca.certificateAuthorityConfiguration().subject().commonName());
+        && commonName.equals(ca.certificateAuthorityConfiguration().subject().commonName())
+        && algorithmFamily
+            .getPcaKeyAlgorithm()
+            .equals(ca.certificateAuthorityConfiguration().keyAlgorithm())
+        && algorithmFamily
+            .getPcaSigningAlgorithm()
+            .equals(ca.certificateAuthorityConfiguration().signingAlgorithm());
   }
 
   private CertificateAuthority createCA() {
@@ -129,7 +139,10 @@ public class PrivateCA {
           ListCertificateAuthoritiesRequest.builder().nextToken(nextToken).build();
       ListCertificateAuthoritiesResponse results = client.listCertificateAuthorities(request);
 
-      discoveredCAs.addAll(results.certificateAuthorities());
+      discoveredCAs.addAll(
+          results.certificateAuthorities().stream()
+              .filter(ca -> ca.status().equals(CertificateAuthorityStatus.ACTIVE))
+              .toList());
       nextToken = results.nextToken();
     } while (Objects.nonNull(nextToken));
 
@@ -243,6 +256,7 @@ public class PrivateCA {
     ImportCertificateAuthorityCertificateRequest importCACertRequest =
         ImportCertificateAuthorityCertificateRequest.builder()
             .certificateAuthorityArn(ca.arn())
+            .certificateChain(SdkBytes.fromUtf8String(getCertificateResult.certificateChain()))
             .certificate(SdkBytes.fromUtf8String(getCertificateResult.certificate()))
             .build();
 

--- a/src/main/java/com/amazonaws/acmpcakms/examples/Runner.java
+++ b/src/main/java/com/amazonaws/acmpcakms/examples/Runner.java
@@ -9,6 +9,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.Security;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -32,62 +33,9 @@ public class Runner {
     return String.join(", ", AlgorithmFamilyRegistry.getSupportedFamilies());
   }
 
-  public static void main(String[] args) throws Exception {
-
-    // Parse command line arguments
-    String filePath;
-    String algorithmFamilyName;
-
-    if (args.length == 0) {
-      // Default case: use default file and algorithm
-      filePath = DEFAULT_FILE_PATH;
-      algorithmFamilyName = DEFAULT_ALGORITHM_FAMILY;
-    } else if (args.length == 1 || args.length > 2) {
-      // Invalid argument count: show usage
-      System.err.println("Usage: java Runner [file_path algorithm]");
-      System.err.println(
-          "  file_path  - Path to the file to sign (default: " + DEFAULT_FILE_PATH + ")");
-      System.err.println(
-          "  algorithm  - Algorithm family to use (default: " + DEFAULT_ALGORITHM_FAMILY + ")");
-      System.err.println();
-      System.err.println("Examples:");
-      System.err.println("  java Runner                                    # Use defaults");
-      System.err.println(
-          "  java Runner myfile.jar RSA2048                # Sign myfile.jar with RSA2048");
-      System.err.println(
-          "  java Runner /path/to/file.bin ECP256           # Sign file with ECP256");
-      System.err.println(
-          "  java Runner document.pdf MLDSA44              # Sign PDF with ML-DSA-44");
-      System.err.println();
-      System.err.println("Supported algorithms: " + getSupportedAlgorithmsString());
-      return;
-    } else {
-      // Two arguments provided
-      filePath = args[0];
-      algorithmFamilyName = args[1];
-    }
-
-    // Validate and get algorithm family
-    AlgorithmFamily algorithmFamily;
-    try {
-      algorithmFamily = AlgorithmFamilyRegistry.getFamily(algorithmFamilyName);
-      System.out.println("Using algorithm family: " + algorithmFamily.getFamilyName());
-      System.out.println("Using file: " + filePath);
-    } catch (IllegalArgumentException e) {
-      System.err.println("Error: " + e.getMessage());
-      System.err.println("Supported algorithms: " + getSupportedAlgorithmsString());
-      return;
-    }
-
-    // Read the file to be signed
-    byte[] dataToSign;
-    try {
-      dataToSign = Files.readAllBytes(Paths.get(filePath));
-      System.out.println("File size: " + dataToSign.length + " bytes");
-    } catch (IOException e) {
-      System.err.println("Error reading file '" + filePath + "': " + e.getMessage());
-      return;
-    }
+  private static void privateCaDemo(AlgorithmFamily algorithmFamily, byte[] dataToSign)
+      throws Exception {
+    byte[] originalDataFromFile = Arrays.copyOf(dataToSign, dataToSign.length);
 
     // Create algorithm-specific names to avoid collisions between different
     // algorithm families
@@ -202,9 +150,6 @@ public class Runner {
     System.out.println();
     System.out.println("Demonstrating verification from separate files\n");
 
-    // Read original data from the original file (not a copy)
-    byte[] originalDataFromFile = Files.readAllBytes(Paths.get(filePath));
-
     // Read and parse CMS signature from .p7s file
     byte[] signatureFromFile = Files.readAllBytes(Paths.get(signatureFileName));
     CMSCodeSigningObject cmsFromFile = CMSCodeSigningObject.fromBytes(signatureFromFile);
@@ -213,5 +158,65 @@ public class Runner {
     cmsFromFile.verifyDetachedSignature(originalDataFromFile, rootCACertificate);
 
     System.out.println("Detached CMS signature verification successful!");
+  }
+
+  public static void main(String[] args) throws Exception {
+
+    // Parse command line arguments
+    String filePath;
+    String algorithmFamilyName;
+
+    if (args.length == 0) {
+      // Default case: use default file and algorithm
+      filePath = DEFAULT_FILE_PATH;
+      algorithmFamilyName = DEFAULT_ALGORITHM_FAMILY;
+    } else if (args.length == 1 || args.length > 2) {
+      // Invalid argument count: show usage
+      System.err.println("Usage: java Runner [file_path algorithm]");
+      System.err.println(
+          "  file_path  - Path to the file to sign (default: " + DEFAULT_FILE_PATH + ")");
+      System.err.println(
+          "  algorithm  - Algorithm family to use (default: " + DEFAULT_ALGORITHM_FAMILY + ")");
+      System.err.println();
+      System.err.println("Examples:");
+      System.err.println("  java Runner                                    # Use defaults");
+      System.err.println(
+          "  java Runner myfile.jar RSA2048                # Sign myfile.jar with RSA2048");
+      System.err.println(
+          "  java Runner /path/to/file.bin ECP256           # Sign file with ECP256");
+      System.err.println(
+          "  java Runner document.pdf MLDSA44              # Sign PDF with ML-DSA-44");
+      System.err.println();
+      System.err.println("Supported algorithms: " + getSupportedAlgorithmsString());
+      return;
+    } else {
+      // Two arguments provided
+      filePath = args[0];
+      algorithmFamilyName = args[1];
+    }
+
+    // Validate and get algorithm family
+    AlgorithmFamily algorithmFamily;
+    try {
+      algorithmFamily = AlgorithmFamilyRegistry.getFamily(algorithmFamilyName);
+      System.out.println("Using algorithm family: " + algorithmFamily.getFamilyName());
+      System.out.println("Using file: " + filePath);
+    } catch (IllegalArgumentException e) {
+      System.err.println("Error: " + e.getMessage());
+      System.err.println("Supported algorithms: " + getSupportedAlgorithmsString());
+      return;
+    }
+
+    // Read the file to be signed
+    byte[] dataToSign;
+    try {
+      dataToSign = Files.readAllBytes(Paths.get(filePath));
+      System.out.println("File size: " + dataToSign.length + " bytes");
+    } catch (IOException e) {
+      System.err.println("Error reading file '" + filePath + "': " + e.getMessage());
+      return;
+    }
+
+    privateCaDemo(algorithmFamily, dataToSign);
   }
 }

--- a/src/main/java/com/amazonaws/acmpcakms/examples/Runner.java
+++ b/src/main/java/com/amazonaws/acmpcakms/examples/Runner.java
@@ -16,7 +16,7 @@ import software.amazon.awssdk.services.acmpca.model.*;
 
 public class Runner {
 
-  private static final String DEFAULT_ALGORITHM_FAMILY = "RSA2048";
+  private static final String DEFAULT_ALGORITHM_FAMILY = AlgorithmFamilyRegistry.RSA2048.getName();
   private static final String DEFAULT_FILE_PATH =
       "target/diy-code-signing-kms-private-ca-1.0-SNAPSHOT.jar";
   private static final String ROOT_COMMON_NAME = "CodeSigningRoot";

--- a/src/main/java/com/amazonaws/acmpcakms/examples/algorithms/AlgorithmFamilyRegistry.java
+++ b/src/main/java/com/amazonaws/acmpcakms/examples/algorithms/AlgorithmFamilyRegistry.java
@@ -7,24 +7,45 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public final class AlgorithmFamilyRegistry {
+public enum AlgorithmFamilyRegistry {
+  RSA2048("RSA2048", new RSA2048Family()),
+  RSA3072("RSA3072", new RSA3072Family()),
+  RSA4096("RSA4096", new RSA4096Family()),
+  ECP256("ECP256", new ECP256Family()),
+  ECP384("ECP384", new ECP384Family()),
+  ECP521("ECP521", new ECP521Family()),
+  MLDSA44("MLDSA44", new MLDSA44Family()),
+  MLDSA65("MLDSA65", new MLDSA65Family()),
+  MLDSA87("MLDSA87", new MLDSA87Family());
 
   // Using Map.of() for immutability and better performance
   private static final Map<String, AlgorithmFamily> FAMILIES =
       Map.of(
-          "RSA2048", new RSA2048Family(),
-          "RSA3072", new RSA3072Family(),
-          "RSA4096", new RSA4096Family(),
-          "ECP256", new ECP256Family(),
-          "ECP384", new ECP384Family(),
-          "ECP521", new ECP521Family(),
-          "MLDSA44", new MLDSA44Family(),
-          "MLDSA65", new MLDSA65Family(),
-          "MLDSA87", new MLDSA87Family());
+          RSA2048.getName(), RSA2048.getFamily(),
+          RSA3072.getName(), RSA3072.getFamily(),
+          RSA4096.getName(), RSA4096.getFamily(),
+          ECP256.getName(), ECP256.getFamily(),
+          ECP384.getName(), ECP384.getFamily(),
+          ECP521.getName(), ECP521.getFamily(),
+          MLDSA44.getName(), MLDSA44.getFamily(),
+          MLDSA65.getName(), MLDSA65.getFamily(),
+          MLDSA87.getName(), MLDSA87.getFamily());
+
+  private final String name;
+  private final AlgorithmFamily family;
 
   // Private constructor to prevent instantiation
-  private AlgorithmFamilyRegistry() {
-    throw new UnsupportedOperationException("Utility class cannot be instantiated");
+  private AlgorithmFamilyRegistry(String name, AlgorithmFamily family) {
+    this.name = name;
+    this.family = family;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public AlgorithmFamily getFamily() {
+    return family;
   }
 
   public static AlgorithmFamily getFamily(String familyName) {

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,0 +1,30 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this
+# software and associated documentation files (the "Software"), to deal in the Software
+# without restriction, including without limitation the rights to use, copy, modify,
+# merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+# PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# Setup a basic logger that logs to the the console
+log4j.rootLogger=INFO, A1
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+
+# For more log info you can use this formater which includes time, thread name, priority, and category
+#log4j.appender.A1.layout.ConversionPattern=%d [%t] %p %c - %m%n
+
+log4j.appender.A1.layout.ConversionPattern=%m%n
+
+# Additional properties to enable more debugging
+#log4j.logger.com.amazonaws.kms=DEBUG
+#log4j.logger.httpclient.wire=DEBUG
+#log4j.logger.com.amazonaws=DEBUG


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Makes the following changes:
 1. Enables PQ TLS when connecting to KMS and ACM endpoints using the AWS CommonRuntime client.
 2. Updates `AlgorithmFamilyRegistry` to an enum to allow users to use autocomplete on `AlgorithmFamilyRegistry` to switch the default algorithm in Runner.java
 3. Removes hard-coded `us-east-1` region to instead use the default region in the user's AWS config
 4. Fixes a few edge cases in PrivateCA.java

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
